### PR TITLE
feat: UIS-2059: send push notification to the mobile app on web UI login

### DIFF
--- a/ut-user/helpers.js
+++ b/ut-user/helpers.js
@@ -450,4 +450,22 @@ Helpers.prototype.validateRestrictedIPRanges = function(ip, restrictedIPRanges) 
     return ipInRestrictedRange;
 };
 
+Helpers.prototype.sendSessionExpiredNotificationToMobileChannel = function(actorId) {
+    return importMethod('alert.push.notification.send')({
+        actorId: actorId,
+        data: {
+            notificationData: {
+                recordId: (new Date()).getTime(),
+                securityRestrictions: 'none',
+                duration: 10,
+                type: 'session_expired'
+            }
+        }
+    }, {
+        auth: {
+            actorId: actorId
+        }
+    });
+};
+
 module.exports = Helpers;

--- a/ut-user/index.js
+++ b/ut-user/index.js
@@ -277,6 +277,13 @@ module.exports = {
                     response = helpers.parseMobileOfflineResponse(response);
                 }
                 return response;
+            }).then(function(response) {
+                if (creatingSession && response['identity.check'].deletedChannel === 'mobile' && response['identity.check'].channel !== 'mobile') {
+                    return helpers
+                        .sendSessionExpiredNotificationToMobileChannel(response['identity.check'].actorId)
+                        .then(() => response);
+                }
+                return response;
             })
             .catch(function(error) {
                 return helpers.handleFullError(error, msg, $meta);

--- a/ut-user/validations.js
+++ b/ut-user/validations.js
@@ -46,7 +46,8 @@ module.exports = {
                 userAgent: joi.string().allow('').allow(null).required(),
                 expire: joi.date().required(),
                 dateCreated: joi.date().required(),
-                channel: joi.string().valid(['web', 'mobile'])
+                channel: joi.string().valid(['web', 'mobile']),
+                deletedChannel: joi.string().valid(['web', 'mobile'])
             }),
             'permission.get': joi.array().items({
                 actionId: joi.string().required(),


### PR DESCRIPTION
When a user logs into the web UI and was previously logged in the mobile app - send a push notification to automatically logout the user from the mobile app.